### PR TITLE
Fix: Three.js canvas resizing error

### DIFF
--- a/apps/blog/app/_components/ThreeJs.tsx
+++ b/apps/blog/app/_components/ThreeJs.tsx
@@ -9,8 +9,8 @@ interface ThreejsProps {
 }
 
 const ThreeJsContent = styled.div`
-  width: 100%;
-  height: 100%;
+  min-width: 100%;
+  min-height: 100%;
 `;
 
 const ThreeJs = ({ isMouseHandler }: ThreejsProps) => {
@@ -42,6 +42,7 @@ const ThreeJs = ({ isMouseHandler }: ThreejsProps) => {
     // renderer instance 생성과 동시에 렌더링 할 곳의 크기 설정 - 렌더링할 구역의 높이와 너비를 설정하는 방법
     // 성능 개선 시 사용 가능
     renderer.setSize(mount.clientWidth, mount.clientHeight);
+    renderer.setClearColor(0xffffff);
     // renderer element를 HTML 문서 내에 삽입 - <canvas> 에리먼트로 renderer가 scene을 나타내는 구역역
     mount.appendChild(renderer.domElement);
 
@@ -155,7 +156,7 @@ const ThreeJs = ({ isMouseHandler }: ThreejsProps) => {
     };
   }, [isMouseActive]);
 
-  return <ThreeJsContent ref={mountRef}></ThreeJsContent>;
+  return <ThreeJsContent ref={mountRef} />;
 };
 
 export default ThreeJs;

--- a/apps/blog/app/page.tsx
+++ b/apps/blog/app/page.tsx
@@ -15,14 +15,12 @@ const HomeWrapper = styled.div`
 const HomeContent = styled.section`
   width: 100%;
   height: 100%;
-  overflow: auto;
+  overflow: hidden;
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   grid-template-rows: repeat(2, 1fr);
   align-self: center;
 `;
-
-const SVG = styled.svg``;
 
 export default function Home() {
   return (


### PR DESCRIPTION
[ Fix ]
- Three.js canvas 사이즈를 width, height 100%로 부여했을 때 발생
- resize 이벤트를 통해 늘리는 경우에는 적용이 잘 됨
- 줄이는 경우 이벤트 감지는 하나, width, height 값에 변동이 없어 UI가 깨짐
- min-width, min-height 값으로 수정하여, 부모 Grid에 값에 따라가도록 강제성을 부여하여 해결함